### PR TITLE
Fix a couple of bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ endif
 export TARGET	:=	$(shell basename $(CURDIR))
 export TOPDIR	:=	$(CURDIR)
 
+include $(DEVKITARM)/ds_rules
+
 # specify a directory which contains the nitro filesystem
 # this is relative to the Makefile
 NITRO_FILES	:=

--- a/arm9/source/main.c
+++ b/arm9/source/main.c
@@ -32,7 +32,7 @@
 #include "version.h"
 #include "video.h"
 
-const char *DEFAULTFILE = "fat:/tuna-vids.avi";
+const char *DEFAULTFILE = "/tuna-vids.avi";
 
 int main(int argc, const char* argv[])
 {


### PR DESCRIPTION
1. Changed the default path of the video to not read `fat:/`, in order for it to be read from both flashcard and DSi/3DS SD card.
2. Included `ds_rules` in the Makefile to fix the error where ndstool wouldn't be found.